### PR TITLE
Fixed show to not run through location_params

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -6,7 +6,7 @@ class LocationsController < ApplicationController
   end
 
   def show
-    @location = Location.find(location_params)
+    @location = Location.find(params[:id])
   end
 
   def new


### PR DESCRIPTION
Changed the show to accurately use params[:id] so we can show a page

 