### PR TITLE
fixed margins and z-index of container

### DIFF
--- a/app/assets/stylesheets/components/_container.scss
+++ b/app/assets/stylesheets/components/_container.scss
@@ -10,5 +10,7 @@ body {
 
 .content {
   flex: 1 0 auto;
+  z-index: -1;
+  margin: 50px 0;
 }
 


### PR DESCRIPTION
When scrolling, the cards now go behind the header and there's a bit of margin so the content displays in the window