### PR TITLE
Remove double icons from search bar

### DIFF
--- a/app/assets/stylesheets/components/_searchbar.scss
+++ b/app/assets/stylesheets/components/_searchbar.scss
@@ -11,3 +11,7 @@
   height: 70px;
   width: 700px;
 }
+
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance:none;
+}


### PR DESCRIPTION
The blue icon came from the webkit default appearance on seach type inputs and not from algolia.